### PR TITLE
WS2025_Update

### DIFF
--- a/Remove-EdgeStartup.ps1
+++ b/Remove-EdgeStartup.ps1
@@ -1,0 +1,57 @@
+# Removes annoying Edge startup prompts. Used for lab systems to disable sync and other first run experienace stuff.
+#requires -RunAsAdministrator
+#requires -Version 5.1
+
+<#
+
+https://learn.microsoft.com/en-us/deployedge/microsoft-edge-browser-policies/hidefirstrunexperience
+
+HideFirstRunExperience     = 1 (Enabled == hide experience)
+AutoImportAtFirstRun       = 4 (DisabledAutoImport)
+ForceSync                  = 0 (Disabled)
+SyncDisabled               = 1 (Enabled == disable sync)
+BrowserSignin              = 0 (Disabled)
+NonRemovableProfileEnabled = 0 (Disabled)
+
+NewTabPageContentEnabled         = 0 (Disabled)
+NewTabPageAllowedBackgroundTypes = 3 (DisableAll)
+NewTabPageQuickLinksEnabled      = 0 (Disabled)
+
+#>
+
+
+# the root of the Edge registry value path
+$edgRootReg = "HKLM:\SOFTWARE\Policies\Microsoft\Edge"
+
+# a hashtable for reg name to reg value 
+$edgeRegValues = @{
+    HideFirstRunExperience           = 1
+    AutoImportAtFirstRun             = 4
+    ForceSync                        = 0
+    SyncDisabled                     = 1
+    BrowserSignin                    = 0
+    NonRemovableProfileEnable        = 0
+    NewTabPageContentEnabled         = 0
+    NewTabPageAllowedBackgroundTypes = 3
+    NewTabPageQuickLinksEnabled      = 0
+}
+
+
+# all values are DWORD
+$edgeRegType = "Dword"
+
+# create the root path
+try {
+    $null = New-Item -Path $edgRootReg -Force -EA Stop
+} catch {
+    Write-Warning "The reg path already exists: $_"
+}
+
+# add all the registry values
+foreach ($val in $edgeRegValues.Keys) {
+    try {
+        $null = New-ItemProperty -Path $edgRootReg -Name $val -PropertyType $edgeRegType -Value $edgeRegValues["$val"]
+    } catch {
+        Write-Warning "Failed to add $val`: $_"
+    }
+}

--- a/launcher.ps1
+++ b/launcher.ps1
@@ -1,7 +1,10 @@
+# grabs the required files and saves them to C:\Temp, then starts the cusomization process
+#requires -RunAsAdministrator
+#requires -Version 5.1
+
 # Downloads a file from the Internet.
 # Returns the full path to the download.
-function Get-WebFile
-{
+function Get-WebFile {
     param ( 
         [string]$URI,
         [string]$Path,
@@ -127,18 +130,22 @@ function Get-WebFile
     return $OutFile
 }
 
-# find the script path, use PWD as the backup
+<# find the script path, use PWD as the backup
 if ( [string]::IsNullOrEmpty($PSScriptRoot) ) {
     # set $PWD to scriptPath
     $script:scriptPath = $PWD.Path
 } else {
     $script:scriptPath = $PSScriptRoot
 }
+#>
 
+# use a local temp file
+$script:scriptPath = "C:\Temp"
+$null = mkdir $script:scriptPath -Force -EA SilentlyContinue
 Write-Verbose "scriptPath: $scriptPath"
 
 # make sure all the required files are present and try to download anything missing
-[array]$reqFiles = Invoke-WebRequest 'https://raw.githubusercontent.com/JamesKehr/Initialize-WinTerminal/main/file.json' | ForEach-Object Content | ConvertFrom-Json
+[array]$reqFiles = Invoke-WebRequest 'https://raw.githubusercontent.com/JamesKehr/Initialize-WinTerminal/main/file.json' -UseBasicParsing | ForEach-Object Content | ConvertFrom-Json
 
 # loop through each required file
 foreach ($rf in $reqFiles) {
@@ -152,7 +159,7 @@ foreach ($rf in $reqFiles) {
         Write-Verbose "Downloading a missing file. htRF:`n$($htRF | Format-List | Out-String)`n"
         
         # download
-        $tryDL = $fileList = Get-WebFile @htRF
+        $tryDL = Get-WebFile @htRF
         if (-NOT $tryDL) {
             throw "Failed to download a required file."
         }


### PR DESCRIPTION
Fixed some code to make WS2025/Win11 24H2 work consistently. The changes assume that Windows Terminal is used to run the script, which is the new standard console for Windows.

Added a computer rename prompt. There is currently no switch to disable this.

Added system wide Edge policies that disable sync and first runtime stuff I don't like on my lab systems. There is currently no switch to turn this off, but I will add one in the future.